### PR TITLE
[no-overflow] Remove the overflow hidden from the grid container

### DIFF
--- a/lib/_chaestli__basics.scss
+++ b/lib/_chaestli__basics.scss
@@ -7,7 +7,6 @@
     width: 100%;
 
     margin: auto;
-    overflow: hidden;
 }
 
 @mixin grid--define-row {


### PR DESCRIPTION
This single line is a breaking change and it's worth a major release. But since we don't have a major release yet we could just bump the `v1.0.0` at this point